### PR TITLE
HBASE-16711 Fix hadoop-3.0 profile compile

### DIFF
--- a/hbase-server/src/main/java/org/apache/hadoop/hbase/regionserver/HRegionServer.java
+++ b/hbase-server/src/main/java/org/apache/hadoop/hbase/regionserver/HRegionServer.java
@@ -190,7 +190,7 @@ import org.apache.hadoop.hbase.zookeeper.ZKUtil;
 import org.apache.hadoop.hbase.zookeeper.ZooKeeperNodeTracker;
 import org.apache.hadoop.hbase.zookeeper.ZooKeeperWatcher;
 import org.apache.hadoop.ipc.RemoteException;
-import org.apache.hadoop.metrics.util.MBeanUtil;
+import org.apache.hadoop.metrics2.util.MBeans;
 import org.apache.hadoop.util.ReflectionUtils;
 import org.apache.hadoop.util.StringUtils;
 import org.apache.zookeeper.KeeperException;
@@ -1031,7 +1031,7 @@ public class HRegionServer extends HasThread implements
     }
     // Run shutdown.
     if (mxBean != null) {
-      MBeanUtil.unregisterMBean(mxBean);
+      MBeans.unregister(mxBean);
       mxBean = null;
     }
     if (this.leases != null) this.leases.closeAfterLeasesExpire();

--- a/hbase-server/src/test/java/org/apache/hadoop/hbase/regionserver/TestBulkLoad.java
+++ b/hbase-server/src/test/java/org/apache/hadoop/hbase/regionserver/TestBulkLoad.java
@@ -273,7 +273,7 @@ public class TestBulkLoad {
     HFile.WriterFactory hFileFactory = HFile.getWriterFactoryNoCache(conf);
     // TODO We need a way to do this without creating files
     File hFileLocation = testFolder.newFile();
-    FSDataOutputStream out = new FSDataOutputStream(new FileOutputStream(hFileLocation));
+    FSDataOutputStream out = new FSDataOutputStream(new FileOutputStream(hFileLocation), null);
     try {
       hFileFactory.withOutputStream(out);
       hFileFactory.withFileContext(new HFileContext());

--- a/hbase-thrift/src/main/java/org/apache/hadoop/hbase/thrift/IncrementCoalescer.java
+++ b/hbase-thrift/src/main/java/org/apache/hadoop/hbase/thrift/IncrementCoalescer.java
@@ -40,7 +40,7 @@ import org.apache.hadoop.hbase.thrift.ThriftServerRunner.HBaseHandler;
 import org.apache.hadoop.hbase.thrift.generated.TIncrement;
 import org.apache.hadoop.hbase.util.Bytes;
 import org.apache.hadoop.hbase.util.Threads;
-import org.apache.hadoop.metrics.util.MBeanUtil;
+import org.apache.hadoop.metrics2.util.MBeans;
 import org.apache.thrift.TException;
 
 /**
@@ -171,7 +171,7 @@ public class IncrementCoalescer implements IncrementCoalescerMBean {
         new ThreadPoolExecutor(CORE_POOL_SIZE, CORE_POOL_SIZE, 50, TimeUnit.MILLISECONDS, queue,
             Threads.newDaemonThreadFactory("IncrementCoalescer"));
 
-    MBeanUtil.registerMBean("thrift", "Thrift", this);
+    MBeans.register("thrift", "Thrift", this);
   }
 
   public boolean queueIncrement(TIncrement inc) throws TException {


### PR DESCRIPTION
Eliminates use of removed or deprecated hadoop2 api
- MBeanUtil -> MBeans Hadoop2 has both; Hadoop 3 removes MBeanUtil and uses MBeans
- FSDataOutputStream(OutputStream) -> FSDataOutputStream(OutputStream, FileSystem.Statistics)
- MetricsServlet is removed.  See HADOOP-12504
