### PR TITLE
Merge HBASE-15513 + HBASE-17032 + HBASE-17005

### DIFF
--- a/hbase-client/src/main/java/org/apache/hadoop/hbase/client/PreemptiveFastFailInterceptor.java
+++ b/hbase-client/src/main/java/org/apache/hadoop/hbase/client/PreemptiveFastFailInterceptor.java
@@ -174,9 +174,7 @@ class PreemptiveFastFailInterceptor extends RetryingCallerInterceptor {
     Throwable t2 = ClientExceptionsUtil.translatePFFE(t1);
     boolean isLocalException = !(t2 instanceof RemoteException);
 
-    if ((isLocalException && ClientExceptionsUtil.isConnectionException(t2)) ||
-         ClientExceptionsUtil.isCallQueueTooBigException(t2) ||
-         ClientExceptionsUtil.isCallDroppedException(t2)) {
+    if ((isLocalException && ClientExceptionsUtil.isConnectionException(t2))) {
       couldNotCommunicateWithServer.setValue(true);
       guaranteedClientSideOnly.setValue(!(t2 instanceof CallTimeoutException));
       handleFailureToServer(serverName, t2);

--- a/hbase-server/src/main/java/org/apache/hadoop/hbase/mob/MobFileCache.java
+++ b/hbase-server/src/main/java/org/apache/hadoop/hbase/mob/MobFileCache.java
@@ -117,8 +117,12 @@ public class MobFileCache {
       }
       this.scheduleThreadPool.scheduleAtFixedRate(new EvictionThread(this), period, period,
           TimeUnit.SECONDS);
+
+      LOG.info("MobFileCache enabled with cacheSize=" + mobFileMaxCacheSize +
+          ", evictPeriods=" +  period + "sec, evictRemainRatio=" + evictRemainRatio);
+    } else {
+      LOG.info("MobFileCache disabled");
     }
-    LOG.info("MobFileCache is initialized, and the cache size is " + mobFileMaxCacheSize);
   }
 
   /**

--- a/hbase-server/src/main/java/org/apache/hadoop/hbase/regionserver/MemStoreChunkPool.java
+++ b/hbase-server/src/main/java/org/apache/hadoop/hbase/regionserver/MemStoreChunkPool.java
@@ -57,7 +57,7 @@ public class MemStoreChunkPool implements HeapMemoryTuneObserver {
   private static final Log LOG = LogFactory.getLog(MemStoreChunkPool.class);
   final static String CHUNK_POOL_MAXSIZE_KEY = "hbase.hregion.memstore.chunkpool.maxsize";
   final static String CHUNK_POOL_INITIALSIZE_KEY = "hbase.hregion.memstore.chunkpool.initialsize";
-  final static float POOL_MAX_SIZE_DEFAULT = 0.0f;
+  final static float POOL_MAX_SIZE_DEFAULT = 1.0f;
   final static float POOL_INITIAL_SIZE_DEFAULT = 0.0f;
 
   // Static reference to the MemStoreChunkPool

--- a/hbase-server/src/test/java/org/apache/hadoop/hbase/client/TestFastFail.java
+++ b/hbase-server/src/test/java/org/apache/hadoop/hbase/client/TestFastFail.java
@@ -293,7 +293,7 @@ public class TestFastFail {
   }
 
   @Test
-  public void testCallQueueTooBigException() throws Exception {
+  public void testCallQueueTooBigExceptionDoesntTriggerPffe() throws Exception {
     Admin admin = TEST_UTIL.getHBaseAdmin();
 
     final String tableName = "testCallQueueTooBigException";
@@ -327,7 +327,8 @@ public class TestFastFail {
     } catch (Throwable ex) {
     }
 
-    assertEquals("There should have been 1 hit", 1,
+    assertEquals("We should have not entered PFFE mode on CQTBE, but we did;"
+      + " number of times this mode should have been entered:", 0,
       CallQueueTooBigPffeInterceptor.numCallQueueTooBig.get());
 
     newConf = HBaseConfiguration.create(TEST_UTIL.getConfiguration());


### PR DESCRIPTION
HBASE-15513 hbase.hregion.memstore.chunkpool.maxsize is 0.0 by default (Vladimir Rodionov)
HBASE-17032 CallQueueTooBigException and CallDroppedException should not be triggering PFFE
HBASE-17005 Improve log message in MobFileCache (huaxiang sun)